### PR TITLE
Fix Tailwind config alias and Supabase RPC typing

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,8 @@
 import { defineNuxtConfig } from 'nuxt/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
 
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
@@ -16,7 +20,16 @@ export default defineNuxtConfig({
     '@nuxt/icon',
     '@nuxt/ui'
   ],
+  alias: {
+    '#tailwind-config': resolve(currentDir, 'tailwind-config')
+  },
   css: ['~/assets/css/tailwind.css', '~/assets/css/theme.css'],
+  postcss: {
+    plugins: {
+      tailwindcss: {},
+      autoprefixer: {}
+    }
+  },
   tailwindcss: {
     viewer: true
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
-}

--- a/src/pages/auth/callback.vue
+++ b/src/pages/auth/callback.vue
@@ -14,8 +14,19 @@ const client = useSupabaseClient<Database>()
 const route = useRoute()
 
 onMounted(async () => {
-  const query = new URLSearchParams(route.query as Record<string, string | string[]>).toString()
-  await client.auth.exchangeCodeForSession(query)
+  const query = new URLSearchParams()
+  Object.entries(route.query).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item != null) {
+          query.append(key, item)
+        }
+      })
+    } else if (value != null) {
+      query.append(key, value)
+    }
+  })
+  await client.auth.exchangeCodeForSession(query.toString())
   await navigateTo('/')
 })
 </script>

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -6,7 +6,7 @@ export type GenericTable = {
 }
 
 export type GenericFunction = {
-  Args: Record<string, unknown> | undefined
+  Args: Record<string, unknown>
   Returns: unknown
 }
 

--- a/tailwind-config/theme/colors.ts
+++ b/tailwind-config/theme/colors.ts
@@ -1,0 +1,7 @@
+import tailwindConfig from '../../tailwind.config'
+
+const colors = {
+  ...(tailwindConfig.theme?.extend?.colors ?? {})
+}
+
+export default colors


### PR DESCRIPTION
## Summary
- add a Nuxt alias for `#tailwind-config`, move the PostCSS setup into Nuxt config, and expose Tailwind colors for Nuxt UI
- serialize the auth callback query parameters safely before exchanging the Supabase session code
- tighten the Supabase generic function typing so RPC calls accept payload objects

## Testing
- npm run lint *(fails: project still uses legacy ESLint config and needs migration to eslint.config.js)*
- npx --yes vue-tsc --noEmit *(fails until Nuxt generates its `.nuxt` directory; run `npx nuxi prepare` first)*

------
https://chatgpt.com/codex/tasks/task_e_68dabce51844832d8b5a039308a0a5cf