### PR TITLE
Fix Supabase RPC argument typings

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -6,15 +6,132 @@ export type GenericTable = {
 }
 
 export type GenericFunction = {
-  Args: Record<string, unknown>
+  Args: Record<string, unknown> | undefined
   Returns: unknown
 }
 
+type ProfilesTable = {
+  Row: Record<string, unknown>
+  Insert: Record<string, unknown>
+  Update: {
+    full_name?: string | null
+    phone?: string | null
+    [key: string]: unknown
+  }
+  Relationships?: never
+}
+
+type SupabaseFunctions = {
+  get_calendar_events: {
+    Args: {
+      p_start: string
+      p_end: string
+    }
+    Returns: unknown
+  }
+  create_check_plan: {
+    Args: {
+      payload: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  create_check_log: {
+    Args: {
+      payload: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  get_check_summary: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+  get_due_checks: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+  get_check_types: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+  upsert_check_type: {
+    Args: {
+      payload: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  delete_check_type: {
+    Args: {
+      id: string
+    }
+    Returns: unknown
+  }
+  download_vehicle_file: {
+    Args: {
+      file_id: string
+    }
+    Returns: unknown
+  }
+  delete_vehicle_file: {
+    Args: {
+      file_id: string
+    }
+    Returns: unknown
+  }
+  get_client_files: {
+    Args: {
+      filters: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  generate_report: {
+    Args: {
+      config: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  get_report_history: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+  save_notification_settings: {
+    Args: {
+      settings: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  get_active_profile: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+  get_client_vehicles: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+  get_vehicle_detail: {
+    Args: {
+      p_vehicle_id: string
+    }
+    Returns: unknown
+  }
+  upsert_vehicle: {
+    Args: {
+      payload: Record<string, unknown>
+    }
+    Returns: unknown
+  }
+  export_client_vehicles: {
+    Args: Record<string, never>
+    Returns: unknown
+  }
+} & Record<string, GenericFunction>
+
 export type Database = {
   public: {
-    Tables: Record<string, GenericTable>
+    Tables: {
+      profiles: ProfilesTable
+    } & Record<string, GenericTable>
     Views: Record<string, GenericTable>
-    Functions: Record<string, GenericFunction>
+    Functions: SupabaseFunctions
     Enums: Record<string, unknown>
     CompositeTypes: Record<string, unknown>
   }


### PR DESCRIPTION
## Summary
- define explicit Supabase RPC argument shapes used throughout the stores
- allow Supabase function typings to accept parameters without TypeScript errors
- declare the profiles table update shape so profile mutations compile cleanly

## Testing
- `npx vue-tsc --noEmit` *(fails: nuxt composables and macros are not available in the isolated type-check environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dacdc6b894832d941ccc2ed7935972