### PR TITLE
fix: guard theme toggle during SSR

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -2,10 +2,16 @@ export const useTheme = () => {
   const preference = useState<'light' | 'dark'>('theme-preference', () => 'light')
 
   watchEffect(() => {
+    if (!import.meta.client) {
+      return
+    }
+
+    const root = document.documentElement
+
     if (preference.value === 'dark') {
-      document.documentElement.classList.add('dark')
+      root.classList.add('dark')
     } else {
-      document.documentElement.classList.remove('dark')
+      root.classList.remove('dark')
     }
   })
 


### PR DESCRIPTION
## Summary
- prevent the theme composable from touching `document` during SSR by checking the client environment first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad8376860832d82d49666bedf303d