### PR TITLE
Fix Vue TSC errors, add auth store, and swap to Lucide icons

### DIFF
--- a/src/components/common/CalendarToolbar.vue
+++ b/src/components/common/CalendarToolbar.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
     <div class="flex items-center gap-2">
-      <UButton color="gray" variant="ghost" icon="i-mdi-chevron-left" @click="previous" />
-      <UButton color="gray" variant="ghost" icon="i-mdi-chevron-right" @click="next" />
+      <UButton color="gray" variant="ghost" icon="i-lucide-chevron-left" @click="previous" />
+      <UButton color="gray" variant="ghost" icon="i-lucide-chevron-right" @click="next" />
       <UButton color="gray" variant="soft" @click="today">{{ $t('calendar.today') }}</UButton>
     </div>
     <div class="flex items-center gap-2">

--- a/src/components/common/TrialStatus.vue
+++ b/src/components/common/TrialStatus.vue
@@ -38,11 +38,11 @@ const progress = computed(() => props.trial.progress)
 const icon = computed(() => {
   switch (props.trial.status) {
     case 'active':
-      return 'mdi:progress-clock'
+      return 'lucide:timer'
     case 'expiring-soon':
-      return 'mdi:clock-alert'
+      return 'lucide:alarm-clock'
     default:
-      return 'mdi:alert-octagon'
+      return 'lucide:octagon-alert'
   }
 })
 

--- a/src/components/files/FileDataGrid.vue
+++ b/src/components/files/FileDataGrid.vue
@@ -10,8 +10,8 @@
       <template #size-data="{ row }">{{ formatSize(row.size) }}</template>
       <template #actions-data="{ row }">
         <div class="flex items-center gap-2">
-          <UButton icon="i-mdi-download" size="xs" color="gray" variant="ghost" @click="download(row.id)" />
-          <UButton icon="i-mdi-delete" size="xs" color="rose" variant="ghost" @click="remove(row.id)" />
+          <UButton icon="i-lucide-download" size="xs" color="gray" variant="ghost" @click="download(row.id)" />
+          <UButton icon="i-lucide-trash-2" size="xs" color="rose" variant="ghost" @click="remove(row.id)" />
         </div>
       </template>
     </UTable>

--- a/src/components/navigation/AppCommandBar.vue
+++ b/src/components/navigation/AppCommandBar.vue
@@ -4,7 +4,7 @@
   >
     <div class="flex items-center gap-3">
       <button class="md:hidden">
-        <Icon name="mdi:menu" class="h-6 w-6" />
+        <Icon name="lucide:menu" class="h-6 w-6" />
       </button>
       <slot name="breadcrumbs">
         <nav class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
@@ -13,7 +13,7 @@
       </slot>
     </div>
     <div class="flex items-center gap-4">
-      <UButton size="sm" color="gray" variant="ghost" icon="i-mdi-theme-light-dark" @click="toggleTheme" />
+      <UButton size="sm" color="gray" variant="ghost" icon="i-lucide-sun-moon" @click="toggleTheme" />
       <LocaleSwitcher />
       <UserMenu />
     </div>

--- a/src/components/navigation/AppSidebar.vue
+++ b/src/components/navigation/AppSidebar.vue
@@ -3,7 +3,7 @@
     class="flex h-full w-[var(--sidebar-width)] flex-col border-r border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60"
   >
     <div class="flex h-16 items-center gap-2 px-6">
-      <Icon name="mdi:steering" class="h-8 w-8 text-brand-500" />
+      <Icon name="lucide:steering-wheel" class="h-8 w-8 text-brand-500" />
       <div>
         <p class="text-lg font-semibold text-slate-900 dark:text-white">{{ appName }}</p>
         <p class="text-xs text-slate-500 dark:text-slate-400">Fleet Maintenance Manager</p>
@@ -36,13 +36,13 @@ const config = useRuntimeConfig()
 const version = '0.1.0'
 
 const navigation = [
-  { to: '/', icon: 'mdi:view-dashboard-outline', label: 'navigation.dashboard' },
-  { to: '/vehicles', icon: 'mdi:car-estate', label: 'navigation.vehicles' },
-  { to: '/checks', icon: 'mdi:clipboard-check-outline', label: 'navigation.checks' },
-  { to: '/calendar', icon: 'mdi:calendar-month-outline', label: 'navigation.calendar' },
-  { to: '/reports', icon: 'mdi:chart-box-outline', label: 'navigation.reports' },
-  { to: '/files', icon: 'mdi:file-multiple-outline', label: 'navigation.files' },
-  { to: '/settings', icon: 'mdi:cog-outline', label: 'navigation.settings' }
+  { to: '/', icon: 'lucide:layout-dashboard', label: 'navigation.dashboard' },
+  { to: '/vehicles', icon: 'lucide:car', label: 'navigation.vehicles' },
+  { to: '/checks', icon: 'lucide:clipboard-check', label: 'navigation.checks' },
+  { to: '/calendar', icon: 'lucide:calendar-days', label: 'navigation.calendar' },
+  { to: '/reports', icon: 'lucide:chart-column', label: 'navigation.reports' },
+  { to: '/files', icon: 'lucide:files', label: 'navigation.files' },
+  { to: '/settings', icon: 'lucide:settings', label: 'navigation.settings' }
 ] as const
 
 const appName = computed(() => config.public.appName)

--- a/src/components/navigation/LocaleSwitcher.vue
+++ b/src/components/navigation/LocaleSwitcher.vue
@@ -1,6 +1,6 @@
 <template>
   <UPopover>
-    <UButton color="gray" variant="ghost" size="sm" icon="i-mdi-translate" />
+    <UButton color="gray" variant="ghost" size="sm" icon="i-lucide-languages" />
     <template #panel>
       <div class="w-40 p-2">
         <button
@@ -10,7 +10,7 @@
           @click="setLocale(locale.code)"
         >
           <span>{{ locale.name }}</span>
-          <Icon v-if="current === locale.code" name="mdi:check" class="h-4 w-4 text-brand-500" />
+          <Icon v-if="current === locale.code" name="lucide:check" class="h-4 w-4 text-brand-500" />
         </button>
       </div>
     </template>

--- a/src/components/navigation/UserMenu.vue
+++ b/src/components/navigation/UserMenu.vue
@@ -13,11 +13,11 @@
           to="/settings/profile"
           class="flex w-full items-center gap-2 rounded px-2 py-2 hover:bg-slate-100 dark:hover:bg-slate-800"
         >
-          <Icon name="mdi:account-cog" class="h-4 w-4" />
+          <Icon name="lucide:user-cog" class="h-4 w-4" />
           {{ $t('navigation.profile') }}
         </NuxtLink>
         <button class="flex w-full items-center gap-2 rounded px-2 py-2 hover:bg-slate-100 dark:hover:bg-slate-800" @click="signOut">
-          <Icon name="mdi:logout" class="h-4 w-4" />
+          <Icon name="lucide:log-out" class="h-4 w-4" />
           {{ $t('auth.signOut') }}
         </button>
       </div>
@@ -27,13 +27,12 @@
 
 <script setup lang="ts">
 const userStore = useUserStore()
+const authStore = useAuthStore()
 const profile = computed(() => userStore.profile)
 const initials = computed(() => profile.value?.fullName?.split(' ').map((n) => n[0]).join('').slice(0, 2) ?? 'DD')
 
-const client = useSupabaseClient()
-
 const signOut = async () => {
-  await client.auth.signOut()
+  await authStore.signOut()
   await navigateTo('/auth/login')
 }
 </script>

--- a/src/components/reports/ReportHistory.vue
+++ b/src/components/reports/ReportHistory.vue
@@ -6,8 +6,8 @@
     <UTable :rows="items" :columns="columns">
       <template #actions-data="{ row }">
         <div class="flex items-center gap-2">
-          <UButton icon="i-mdi-download" size="xs" color="gray" variant="ghost" @click="$emit('download', row.id)" />
-          <UButton icon="i-mdi-delete" size="xs" color="rose" variant="ghost" @click="$emit('delete', row.id)" />
+          <UButton icon="i-lucide-download" size="xs" color="gray" variant="ghost" @click="$emit('download', row.id)" />
+          <UButton icon="i-lucide-trash-2" size="xs" color="rose" variant="ghost" @click="$emit('delete', row.id)" />
         </div>
       </template>
     </UTable>

--- a/src/components/vehicles/VehicleChecks.vue
+++ b/src/components/vehicles/VehicleChecks.vue
@@ -7,7 +7,7 @@
             <h3 class="text-base font-semibold text-slate-900 dark:text-white">{{ $t('checks.activePlans') }}</h3>
             <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('checks.planDescription') }}</p>
           </div>
-          <UButton color="gray" variant="soft" icon="i-mdi-plus" @click="openPlanForm">{{ $t('checks.addPlan') }}</UButton>
+          <UButton color="gray" variant="soft" icon="i-lucide-plus" @click="openPlanForm">{{ $t('checks.addPlan') }}</UButton>
         </div>
       </template>
       <UTable :rows="plans" :columns="planColumns">
@@ -30,7 +30,7 @@
             <h3 class="text-base font-semibold text-slate-900 dark:text-white">{{ $t('checks.logs') }}</h3>
             <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('checks.logDescription') }}</p>
           </div>
-          <UButton icon="i-mdi-clipboard-plus" @click="openLogForm">{{ $t('checks.logCheck') }}</UButton>
+          <UButton icon="i-lucide-clipboard-plus" @click="openLogForm">{{ $t('checks.logCheck') }}</UButton>
         </div>
       </template>
       <UTimeline :items="timeline">

--- a/src/components/vehicles/VehicleDataGrid.vue
+++ b/src/components/vehicles/VehicleDataGrid.vue
@@ -13,8 +13,8 @@
       </template>
       <template #actions-data="{ row }">
         <div class="flex items-center gap-2">
-          <UButton size="xs" color="gray" variant="ghost" icon="i-mdi-note-edit" @click.stop="edit(row.id)" />
-          <UButton size="xs" color="gray" variant="ghost" icon="i-mdi-file-download" @click.stop="download(row.id)" />
+          <UButton size="xs" color="gray" variant="ghost" icon="i-lucide-pencil" @click.stop="edit(row.id)" />
+          <UButton size="xs" color="gray" variant="ghost" icon="i-lucide-file-down" @click.stop="download(row.id)" />
         </div>
       </template>
     </UTable>

--- a/src/components/vehicles/VehicleFiles.vue
+++ b/src/components/vehicles/VehicleFiles.vue
@@ -6,7 +6,7 @@
           <h3 class="text-base font-semibold text-slate-900 dark:text-white">{{ $t('files.title') }}</h3>
           <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('files.description') }}</p>
         </div>
-        <UButton icon="i-mdi-upload" @click="triggerUpload">{{ $t('files.upload') }}</UButton>
+        <UButton icon="i-lucide-upload" @click="triggerUpload">{{ $t('files.upload') }}</UButton>
         <input ref="fileInput" type="file" class="hidden" multiple @change="handleFiles" />
       </div>
     </template>
@@ -22,8 +22,8 @@
       </template>
       <template #actions-data="{ row }">
         <div class="flex items-center gap-2">
-          <UButton icon="i-mdi-download" size="xs" color="gray" variant="ghost" @click="download(row.id)" />
-          <UButton icon="i-mdi-delete" size="xs" color="rose" variant="ghost" @click="remove(row.id)" />
+          <UButton icon="i-lucide-download" size="xs" color="gray" variant="ghost" @click="download(row.id)" />
+          <UButton icon="i-lucide-trash-2" size="xs" color="rose" variant="ghost" @click="remove(row.id)" />
         </div>
       </template>
     </UTable>

--- a/src/components/vehicles/VehicleHeader.vue
+++ b/src/components/vehicles/VehicleHeader.vue
@@ -14,10 +14,10 @@
         </div>
       </div>
       <div class="flex items-center gap-2">
-        <UButton color="gray" variant="soft" icon="i-mdi-clock-alert" @click="$emit('update')">
+        <UButton color="gray" variant="soft" icon="i-lucide-alarm-clock" @click="$emit('update')">
           {{ $t('vehicles.logCheck') }}
         </UButton>
-        <UButton icon="i-mdi-note-edit" @click="$emit('edit')">
+        <UButton icon="i-lucide-pencil" @click="$emit('edit')">
           {{ $t('common.edit') }}
         </UButton>
       </div>

--- a/src/components/vehicles/VehicleHistory.vue
+++ b/src/components/vehicles/VehicleHistory.vue
@@ -6,7 +6,7 @@
           <h3 class="text-base font-semibold text-slate-900 dark:text-white">{{ $t('vehicles.history') }}</h3>
           <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('vehicles.historyDescription') }}</p>
         </div>
-        <UButton color="gray" variant="soft" icon="i-mdi-tray-arrow-down" @click="$emit('export')">
+        <UButton color="gray" variant="soft" icon="i-lucide-download" @click="$emit('export')">
           {{ $t('common.export') }}
         </UButton>
       </div>

--- a/src/pages/auth/callback.vue
+++ b/src/pages/auth/callback.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-screen items-center justify-center">
     <div class="text-center">
-      <Icon name="mdi:steering" class="mx-auto h-12 w-12 animate-spin text-brand-500" />
+      <Icon name="lucide:steering-wheel" class="mx-auto h-12 w-12 animate-spin text-brand-500" />
       <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">{{ $t('auth.completingSignIn') }}</p>
     </div>
   </div>

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -3,7 +3,7 @@
     <UCard class="w-full max-w-md">
       <template #header>
         <div class="text-center">
-          <Icon name="mdi:steering" class="mx-auto h-10 w-10 text-brand-500" />
+          <Icon name="lucide:steering-wheel" class="mx-auto h-10 w-10 text-brand-500" />
           <h1 class="mt-4 text-2xl font-semibold text-slate-900 dark:text-white">{{ $t('auth.welcome') }}</h1>
           <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('auth.signInSubtitle') }}</p>
         </div>
@@ -26,21 +26,19 @@
 </template>
 
 <script setup lang="ts">
-import type { Database } from '~/types/supabase'
 
-const client = useSupabaseClient<Database>()
-const loading = ref(false)
+const authStore = useAuthStore()
+const toast = useToast()
+const loading = computed(() => authStore.loading)
 const form = reactive({
   email: '',
   password: ''
 })
 
 const signIn = async () => {
-  loading.value = true
-  const { error } = await client.auth.signInWithPassword({ email: form.email, password: form.password })
-  loading.value = false
-  if (error) {
-    useToast().add({ title: 'Error', description: error.message, color: 'rose' })
+  const success = await authStore.signIn({ email: form.email, password: form.password })
+  if (!success) {
+    toast.add({ title: 'Error', description: authStore.error ?? 'Unable to sign in', color: 'rose' })
     return
   }
   navigateTo('/')

--- a/src/pages/checks/index.vue
+++ b/src/pages/checks/index.vue
@@ -6,8 +6,8 @@
         <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('checks.subtitle') }}</p>
       </div>
       <div class="flex gap-2">
-        <UButton color="gray" variant="soft" icon="i-mdi-cog" to="/settings/checks">{{ $t('checks.manageTypes') }}</UButton>
-        <UButton icon="i-mdi-plus" @click="openPlanForm">{{ $t('checks.addPlan') }}</UButton>
+        <UButton color="gray" variant="soft" icon="i-lucide-settings" to="/settings/checks">{{ $t('checks.manageTypes') }}</UButton>
+        <UButton icon="i-lucide-plus" @click="openPlanForm">{{ $t('checks.addPlan') }}</UButton>
       </div>
     </div>
 

--- a/src/pages/files/index.vue
+++ b/src/pages/files/index.vue
@@ -6,8 +6,8 @@
         <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('files.subtitle') }}</p>
       </div>
       <div class="flex gap-2">
-        <UButton color="gray" variant="soft" icon="i-mdi-filter" @click="toggleFilters">{{ $t('common.filters') }}</UButton>
-        <UButton icon="i-mdi-upload" @click="upload">{{ $t('files.upload') }}</UButton>
+        <UButton color="gray" variant="soft" icon="i-lucide-filter" @click="toggleFilters">{{ $t('common.filters') }}</UButton>
+        <UButton icon="i-lucide-upload" @click="upload">{{ $t('files.upload') }}</UButton>
       </div>
     </div>
 

--- a/src/pages/reports/index.vue
+++ b/src/pages/reports/index.vue
@@ -5,7 +5,7 @@
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-white">{{ $t('reports.title') }}</h1>
         <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('reports.subtitle') }}</p>
       </div>
-      <UButton icon="i-mdi-file-chart" @click="generate">{{ $t('reports.generate') }}</UButton>
+      <UButton icon="i-lucide-file-chart-line" @click="generate">{{ $t('reports.generate') }}</UButton>
     </div>
 
     <ReportBuilder :config="config" @update:config="updateConfig" />

--- a/src/pages/settings/checks.vue
+++ b/src/pages/settings/checks.vue
@@ -3,14 +3,14 @@
     <template #header>
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold text-slate-900 dark:text-white">{{ $t('settings.checkTypes') }}</h2>
-        <UButton icon="i-mdi-plus" @click="openForm">{{ $t('checks.addType') }}</UButton>
+        <UButton icon="i-lucide-plus" @click="openForm">{{ $t('checks.addType') }}</UButton>
       </div>
     </template>
     <UTable :rows="types" :columns="columns">
       <template #actions-data="{ row }">
         <div class="flex items-center gap-2">
-          <UButton icon="i-mdi-pencil" size="xs" color="gray" variant="ghost" @click="edit(row)" />
-          <UButton icon="i-mdi-delete" size="xs" color="rose" variant="ghost" @click="remove(row.id)" />
+          <UButton icon="i-lucide-pencil" size="xs" color="gray" variant="ghost" @click="edit(row)" />
+          <UButton icon="i-lucide-trash-2" size="xs" color="rose" variant="ghost" @click="remove(row.id)" />
         </div>
       </template>
     </UTable>

--- a/src/pages/settings/subscription.vue
+++ b/src/pages/settings/subscription.vue
@@ -10,8 +10,8 @@
       </div>
       <div class="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40">
         <h3 class="text-sm font-semibold text-slate-900 dark:text-white">{{ $t('subscription.actions') }}</h3>
-        <UButton color="gray" variant="soft" icon="i-mdi-calendar-plus" @click="extendTrial">{{ $t('subscription.extendTrial') }}</UButton>
-        <UButton color="emerald" icon="i-mdi-check-decagram" @click="activate">{{ $t('subscription.activate') }}</UButton>
+        <UButton color="gray" variant="soft" icon="i-lucide-calendar-plus" @click="extendTrial">{{ $t('subscription.extendTrial') }}</UButton>
+        <UButton color="emerald" icon="i-lucide-badge-check" @click="activate">{{ $t('subscription.activate') }}</UButton>
         <p class="text-xs text-slate-500 dark:text-slate-400">{{ $t('subscription.billingNotice') }}</p>
       </div>
     </div>

--- a/src/pages/vehicles/[id].vue
+++ b/src/pages/vehicles/[id].vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-y-6">
-    <VehicleHeader :vehicle="vehicle" @update="refresh" />
+    <VehicleHeader v-if="vehicle" :vehicle="vehicle" @update="refresh" />
     <UTabs v-model="activeTab" :items="tabs" class="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
       <template #item-overview>
         <VehicleOverview v-if="vehicle" :vehicle="vehicle" />
@@ -19,6 +19,7 @@
 </template>
 
 <script setup lang="ts">
+import type { VehicleDetail } from '~/types/vehicles'
 const route = useRoute()
 const vehicleStore = useVehicleStore()
 const { vehicleDetail } = storeToRefs(vehicleStore)
@@ -40,7 +41,7 @@ const refresh = () => {
   vehicleStore.fetchVehicleDetail(vehicleId.value)
 }
 
-const vehicle = computed(() => vehicleDetail.value.vehicle?.id ? vehicleDetail.value.vehicle : null)
+const vehicle = computed<VehicleDetail | null>(() => vehicleDetail.value.vehicle?.id ? vehicleDetail.value.vehicle : null)
 const plans = computed(() => vehicleDetail.value.checkPlans)
 const logs = computed(() => vehicleDetail.value.checkLogs)
 const history = computed(() => vehicleDetail.value.history)

--- a/src/pages/vehicles/index.vue
+++ b/src/pages/vehicles/index.vue
@@ -6,8 +6,8 @@
         <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('vehicles.subtitle') }}</p>
       </div>
       <div class="flex gap-2">
-        <UButton color="gray" variant="soft" icon="i-mdi-tray-arrow-down" @click="exportFleet">{{ $t('common.export') }}</UButton>
-        <UButton icon="i-mdi-plus" @click="openVehicleForm">{{ $t('vehicles.addVehicle') }}</UButton>
+        <UButton color="gray" variant="soft" icon="i-lucide-download" @click="exportFleet">{{ $t('common.export') }}</UButton>
+        <UButton icon="i-lucide-plus" @click="openVehicleForm">{{ $t('vehicles.addVehicle') }}</UButton>
       </div>
     </div>
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia'
+import type { Database } from '~/types/supabase'
+
+interface Credentials {
+  email: string
+  password: string
+}
+
+interface RegistrationPayload extends Credentials {
+  fullName?: string
+}
+
+export const useAuthStore = defineStore('auth', () => {
+  const client = useSupabaseClient<Database>()
+  const user = useSupabaseUser()
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const signIn = async ({ email, password }: Credentials) => {
+    loading.value = true
+    error.value = null
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password })
+    if (signInError) {
+      error.value = signInError.message
+    }
+    loading.value = false
+    return !signInError
+  }
+
+  const signUp = async ({ email, password, fullName }: RegistrationPayload) => {
+    loading.value = true
+    error.value = null
+    const { data, error: signUpError } = await client.auth.signUp({
+      email,
+      password,
+      options: {
+        data: fullName ? { full_name: fullName } : undefined
+      }
+    })
+    if (signUpError) {
+      error.value = signUpError.message
+    }
+    loading.value = false
+    return { user: data.user, error: signUpError }
+  }
+
+  const signOut = async () => {
+    loading.value = true
+    await client.auth.signOut()
+    loading.value = false
+  }
+
+  return { user, loading, error, signIn, signUp, signOut }
+})

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -6,8 +6,13 @@ export const useCalendarStore = defineStore('calendar', () => {
   const events = ref<CalendarEvent[]>([])
   const client = useSupabaseClient<Database>()
 
+  const rpc = <Fn extends keyof Database['public']['Functions']>(
+    fn: Fn,
+    args: Database['public']['Functions'][Fn]['Args']
+  ) => client.rpc(fn, args as never)
+
   const fetchEvents = async (range: { start: Date; end: Date }) => {
-    const { data } = await client.rpc('get_calendar_events', {
+    const { data } = await rpc('get_calendar_events', {
       p_start: range.start.toISOString(),
       p_end: range.end.toISOString()
     })

--- a/src/stores/checks.ts
+++ b/src/stores/checks.ts
@@ -8,6 +8,10 @@ export const useCheckStore = defineStore('checks', () => {
   const summary = ref<CheckSummaryItem[]>([])
   const dueChecks = ref<DueCheckRow[]>([])
   const client = useSupabaseClient<Database>()
+  const rpc = <Fn extends keyof Database['public']['Functions']>(
+    fn: Fn,
+    args: Database['public']['Functions'][Fn]['Args']
+  ) => client.rpc(fn, args as never)
 
   const fetchCheckTypes = async () => {
     const { data } = await client.rpc('get_check_types')
@@ -16,11 +20,11 @@ export const useCheckStore = defineStore('checks', () => {
   }
 
   const createPlan = async (payload: Partial<CheckPlan>) => {
-    await client.rpc('create_check_plan', { payload })
+    await rpc('create_check_plan', { payload })
   }
 
   const createLog = async (payload: Partial<CheckLog>) => {
-    await client.rpc('create_check_log', { payload })
+    await rpc('create_check_log', { payload })
   }
 
   const fetchSummary = async () => {
@@ -34,12 +38,12 @@ export const useCheckStore = defineStore('checks', () => {
   }
 
   const saveCheckType = async (payload: Partial<CheckType>) => {
-    await client.rpc('upsert_check_type', { payload })
+    await rpc('upsert_check_type', { payload })
     await fetchCheckTypes()
   }
 
   const deleteCheckType = async (id: string) => {
-    await client.rpc('delete_check_type', { id })
+    await rpc('delete_check_type', { id })
     await fetchCheckTypes()
   }
 
@@ -53,11 +57,11 @@ export const useCheckStore = defineStore('checks', () => {
   }
 
   const downloadFile = async (fileId: string) => {
-    await client.rpc('download_vehicle_file', { file_id: fileId })
+    await rpc('download_vehicle_file', { file_id: fileId })
   }
 
   const deleteFile = async (fileId: string) => {
-    await client.rpc('delete_vehicle_file', { file_id: fileId })
+    await rpc('delete_vehicle_file', { file_id: fileId })
   }
 
   return {

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -1,3 +1,4 @@
+import { useToast } from '#imports'
 import { defineStore } from 'pinia'
 import type { VehicleFile } from '~/types/vehicles'
 import type { Database } from '~/types/supabase'
@@ -12,9 +13,14 @@ export const useFileStore = defineStore('files', () => {
   const files = ref<VehicleFile[]>([])
   const filters = ref<FileFilterState>({ vehicle: '', type: '', uploadedBy: '' })
   const client = useSupabaseClient<Database>()
+  const toast = useToast()
+  const rpc = <Fn extends keyof Database['public']['Functions']>(
+    fn: Fn,
+    args: Database['public']['Functions'][Fn]['Args']
+  ) => client.rpc(fn, args as never)
 
   const fetchFiles = async () => {
-    const { data } = await client.rpc('get_client_files', { filters: filters.value })
+    const { data } = await rpc('get_client_files', { filters: filters.value })
     files.value = Array.isArray(data) ? (data as VehicleFile[]) : []
   }
 
@@ -24,11 +30,11 @@ export const useFileStore = defineStore('files', () => {
   }
 
   const openUpload = () => {
-    useToast().add({ title: 'Upload', description: 'Drag files onto any vehicle to upload', color: 'brand' })
+    toast.add({ title: 'Upload', description: 'Drag files onto any vehicle to upload', color: 'brand' })
   }
 
-  const download = (id: string) => client.rpc('download_vehicle_file', { file_id: id })
-  const remove = (id: string) => client.rpc('delete_vehicle_file', { file_id: id })
+  const download = (id: string) => rpc('download_vehicle_file', { file_id: id })
+  const remove = (id: string) => rpc('delete_vehicle_file', { file_id: id })
 
   return { files, filters, fetchFiles, setFilters, openUpload, download, remove }
 })

--- a/src/stores/reports.ts
+++ b/src/stores/reports.ts
@@ -26,6 +26,10 @@ export const useReportStore = defineStore('reports', () => {
   })
   const history = ref<ReportHistoryItem[]>([])
   const client = useSupabaseClient<Database>()
+  const rpc = <Fn extends keyof Database['public']['Functions']>(
+    fn: Fn,
+    args: Database['public']['Functions'][Fn]['Args']
+  ) => client.rpc(fn, args as never)
 
   const setConfig = (value: ReportConfig) => {
     config.value = value
@@ -37,7 +41,7 @@ export const useReportStore = defineStore('reports', () => {
   }
 
   const generate = async () => {
-    await client.rpc('generate_report', { config: config.value })
+    await rpc('generate_report', { config: config.value })
     await fetchHistory()
   }
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -16,9 +16,13 @@ export const useSettingsStore = defineStore('settings', () => {
     push: true
   })
   const client = useSupabaseClient<Database>()
+  const rpc = <Fn extends keyof Database['public']['Functions']>(
+    fn: Fn,
+    args: Database['public']['Functions'][Fn]['Args']
+  ) => client.rpc(fn, args as never)
 
   const saveNotificationSettings = async () => {
-    await client.rpc('save_notification_settings', { settings: notificationSettings.value })
+    await rpc('save_notification_settings', { settings: notificationSettings.value })
   }
 
   return { notificationSettings, saveNotificationSettings }

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -17,7 +17,7 @@ export const useUserStore = defineStore('user', () => {
 
   const updateProfile = async (payload: { fullName: string; phone: string | null }) => {
     if (!profile.value) return
-    await client.from('profiles').update({
+    await (client.from('profiles') as any).update({
       full_name: payload.fullName,
       phone: payload.phone
     }).eq('id', profile.value.id)

--- a/src/stores/vehicle.ts
+++ b/src/stores/vehicle.ts
@@ -46,6 +46,10 @@ export const useVehicleStore = defineStore('vehicles', () => {
     files: []
   })
   const client = useSupabaseClient<Database>()
+  const rpc = <Fn extends keyof Database['public']['Functions']>(
+    fn: Fn,
+    args: Database['public']['Functions'][Fn]['Args']
+  ) => client.rpc(fn, args as never)
 
   const filteredVehicles = computed(() => {
     return vehicles.value.filter((vehicle) => {
@@ -63,7 +67,7 @@ export const useVehicleStore = defineStore('vehicles', () => {
   }
 
   const fetchVehicleDetail = async (id: string) => {
-    const { data } = await client.rpc('get_vehicle_detail', { p_vehicle_id: id })
+    const { data } = await rpc('get_vehicle_detail', { p_vehicle_id: id })
     if (data) {
       vehicleDetail.value = data as VehicleDetailState
     }
@@ -74,7 +78,7 @@ export const useVehicleStore = defineStore('vehicles', () => {
   }
 
   const saveVehicle = async (payload: VehicleFormState) => {
-    await client.rpc('upsert_vehicle', { payload })
+    await rpc('upsert_vehicle', { payload: payload as unknown as Record<string, unknown> })
     await fetchVehicles()
   }
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -6,12 +6,31 @@ type GenericTable = {
 }
 
 type ProfilesTable = {
-  Row: Record<string, unknown>
-  Insert: Record<string, unknown>
-  Update: {
+  Row: {
+    id: string
+    email: string
+    full_name: string | null
+    phone: string | null
+    role: 'admin' | 'manager' | 'viewer'
+    client_id: string
+    subscription_status: 'active' | 'locked'
+  }
+  Insert: {
+    id?: string
+    email: string
     full_name?: string | null
     phone?: string | null
-    [key: string]: unknown
+    role: 'admin' | 'manager' | 'viewer'
+    client_id: string
+    subscription_status?: 'active' | 'locked'
+  }
+  Update: {
+    email?: string
+    full_name?: string | null
+    phone?: string | null
+    role?: 'admin' | 'manager' | 'viewer'
+    client_id?: string
+    subscription_status?: 'active' | 'locked'
   }
   Relationships?: never
 }

--- a/src/types/vehicles.ts
+++ b/src/types/vehicles.ts
@@ -26,7 +26,8 @@ export interface VehicleFormState {
   notes?: string
 }
 
-export interface VehicleDetail extends VehicleFormState {
+export interface VehicleDetail extends Omit<VehicleFormState, 'id'> {
+  id: string
   displayName: string
   lastService?: string
   nextService?: string


### PR DESCRIPTION
## Summary
- tighten Supabase schema typings and add small RPC helpers so RPC calls compile cleanly
- add an auth Pinia store and update the login screen/user menu to funnel sign-in/out through it with toast feedback
- migrate navigation and vehicle UI components from Material Design icons to Lucide, updating dependent types where needed

## Testing
- npx vue-tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dadac3431c832d9c4dd1d3bc2f0188