### PR TITLE
Fix missing toast import on login page

### DIFF
--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -27,6 +27,8 @@
 
 <script setup lang="ts">
 
+import { useToast } from '#imports'
+
 const authStore = useAuthStore()
 const toast = useToast()
 const loading = computed(() => authStore.loading)


### PR DESCRIPTION
## Summary
- import useToast in the login page so the toast composable is available at runtime

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae16ae22c832d941c2df04e8dbbae