### PR TITLE
fix: resolve missing #ui module import

### DIFF
--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -27,8 +27,6 @@
 
 <script setup lang="ts">
 
-import { useToast } from '#ui'
-
 const authStore = useAuthStore()
 const toast = useToast()
 const loading = computed(() => authStore.loading)

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia'
-import { useToast } from '#ui'
 import type { VehicleFile } from '~/types/vehicles'
 import type { Database } from '~/types/supabase'
 


### PR DESCRIPTION
## Summary
- remove direct imports from `#ui` in login page and file store to use Nuxt auto-imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae48e2c10832da75cacd159ea98e4