### PR TITLE
fix: import toast composable in file store

### DIFF
--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { useToast } from '#imports'
 import type { VehicleFile } from '~/types/vehicles'
 import type { Database } from '~/types/supabase'
 


### PR DESCRIPTION
## Summary
- import the Nuxt UI toast composable in the file store to resolve the undefined runtime reference

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae63abe5c832db3aa921f6ea7dc5c