### PR TITLE
Fix Nuxt UI color config to prevent runtime error

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -2,6 +2,19 @@ export default defineAppConfig({
   ui: {
     primary: 'brand',
     gray: 'slate',
-    colors: ['brand']
-  } as any
+    colors: {
+      brand: {
+        50: '#ecfeff',
+        100: '#cffafe',
+        200: '#a5f3fc',
+        300: '#67e8f9',
+        400: '#22d3ee',
+        500: '#0ea5e9',
+        600: '#0284c7',
+        700: '#0369a1',
+        800: '#075985',
+        900: '#0c4a6e'
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- replace the Nuxt UI colors array with the full brand color map so the plugin can resolve palette values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae9e079a8832db9aba07b58288118