### PR TITLE
Fix Nuxt UI configuration typing issues

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,20 +1,6 @@
 export default defineAppConfig({
   ui: {
     primary: 'brand',
-    gray: 'slate',
-    colors: {
-      brand: {
-        50: '#ecfeff',
-        100: '#cffafe',
-        200: '#a5f3fc',
-        300: '#67e8f9',
-        400: '#22d3ee',
-        500: '#0ea5e9',
-        600: '#0284c7',
-        700: '#0369a1',
-        800: '#075985',
-        900: '#0c4a6e'
-      }
-    }
+    gray: 'slate'
   }
 })

--- a/src/types/nuxt-ui.d.ts
+++ b/src/types/nuxt-ui.d.ts
@@ -1,0 +1,5 @@
+declare module '#ui' {
+  export const useToast: typeof import('@nuxt/ui/dist/runtime/composables/useToast').useToast
+}
+
+export {}


### PR DESCRIPTION
## Summary
- remove the custom color object from the Nuxt app config so the UI module receives the expected values
- add a Nuxt UI type declaration to expose `useToast` for imports resolved via `#ui`

## Testing
- `npx vue-tsc --noEmit` *(fails: numerous existing missing macro/type definitions in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68daede982c0832d8f7f1aaf3cd901bf