### PR TITLE
Fix Nuxt UI module resolution errors

### DIFF
--- a/tailwind-config/theme/colors.ts
+++ b/tailwind-config/theme/colors.ts
@@ -1,6 +1,8 @@
+import defaultColors from 'tailwindcss/colors'
 import tailwindConfig from '../../tailwind.config'
 
 const colors = {
+  ...defaultColors,
   ...(tailwindConfig.theme?.extend?.colors ?? {})
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "#ui": ["./node_modules/@nuxt/ui/dist/runtime"],
+      "#ui/*": ["./node_modules/@nuxt/ui/dist/runtime/*"],
+      "#tailwind-config/*": ["./tailwind-config/*"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- ensure the Nuxt UI runtime alias is resolved by TypeScript via explicit path mappings
- expose the Tailwind default palette alongside custom colors so Nuxt UI can resolve gray fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daf0a5fc50832d9ef13903af8c86bd