### PR TITLE
Fix vue-tsc alias resolution and generic typing

### DIFF
--- a/src/components/forms/CheckPlanForm.vue
+++ b/src/components/forms/CheckPlanForm.vue
@@ -30,6 +30,7 @@
 
 <script setup lang="ts">
 import type { CheckTypeOption } from '~/types/checks'
+import type { VehicleListItem } from '~/types/vehicles'
 
 interface Props {
   modelValue: boolean
@@ -58,7 +59,7 @@ const form = reactive({
 
 const checkTypeOptions = computed<CheckTypeOption[]>(() => checkStore.options)
 const vehicleOptions = computed(() =>
-  vehicleStore.vehicles.map((vehicle) => ({
+  vehicleStore.vehicles.map((vehicle: VehicleListItem) => ({
     label: `${vehicle.plate} · ${vehicle.make} ${vehicle.model}`,
     value: vehicle.id
   }))

--- a/src/components/navigation/UserMenu.vue
+++ b/src/components/navigation/UserMenu.vue
@@ -29,7 +29,9 @@
 const userStore = useUserStore()
 const authStore = useAuthStore()
 const profile = computed(() => userStore.profile)
-const initials = computed(() => profile.value?.fullName?.split(' ').map((n) => n[0]).join('').slice(0, 2) ?? 'DD')
+const initials = computed(
+  () => profile.value?.fullName?.split(' ').map((n: string) => n[0]).join('').slice(0, 2) ?? 'DD'
+)
 
 const signOut = async () => {
   await authStore.signOut()

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -6,7 +6,7 @@ export const useCalendarStore = defineStore('calendar', () => {
   const events = ref<CalendarEvent[]>([])
   const client = useSupabaseClient<Database>()
 
-  const rpc = <Fn extends keyof Database['public']['Functions']>(
+  const rpc = <Fn extends Extract<keyof Database['public']['Functions'], string>>(
     fn: Fn,
     args: Database['public']['Functions'][Fn]['Args']
   ) => client.rpc(fn, args as never)

--- a/src/stores/checks.ts
+++ b/src/stores/checks.ts
@@ -8,7 +8,7 @@ export const useCheckStore = defineStore('checks', () => {
   const summary = ref<CheckSummaryItem[]>([])
   const dueChecks = ref<DueCheckRow[]>([])
   const client = useSupabaseClient<Database>()
-  const rpc = <Fn extends keyof Database['public']['Functions']>(
+  const rpc = <Fn extends Extract<keyof Database['public']['Functions'], string>>(
     fn: Fn,
     args: Database['public']['Functions'][Fn]['Args']
   ) => client.rpc(fn, args as never)

--- a/src/stores/files.ts
+++ b/src/stores/files.ts
@@ -14,7 +14,7 @@ export const useFileStore = defineStore('files', () => {
   const filters = ref<FileFilterState>({ vehicle: '', type: '', uploadedBy: '' })
   const client = useSupabaseClient<Database>()
   const notifier = useNotifier()
-  const rpc = <Fn extends keyof Database['public']['Functions']>(
+  const rpc = <Fn extends Extract<keyof Database['public']['Functions'], string>>(
     fn: Fn,
     args: Database['public']['Functions'][Fn]['Args']
   ) => client.rpc(fn, args as never)

--- a/src/stores/reports.ts
+++ b/src/stores/reports.ts
@@ -26,7 +26,7 @@ export const useReportStore = defineStore('reports', () => {
   })
   const history = ref<ReportHistoryItem[]>([])
   const client = useSupabaseClient<Database>()
-  const rpc = <Fn extends keyof Database['public']['Functions']>(
+  const rpc = <Fn extends Extract<keyof Database['public']['Functions'], string>>(
     fn: Fn,
     args: Database['public']['Functions'][Fn]['Args']
   ) => client.rpc(fn, args as never)

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -16,7 +16,7 @@ export const useSettingsStore = defineStore('settings', () => {
     push: true
   })
   const client = useSupabaseClient<Database>()
-  const rpc = <Fn extends keyof Database['public']['Functions']>(
+  const rpc = <Fn extends Extract<keyof Database['public']['Functions'], string>>(
     fn: Fn,
     args: Database['public']['Functions'][Fn]['Args']
   ) => client.rpc(fn, args as never)

--- a/src/stores/vehicle.ts
+++ b/src/stores/vehicle.ts
@@ -46,7 +46,7 @@ export const useVehicleStore = defineStore('vehicles', () => {
     files: []
   })
   const client = useSupabaseClient<Database>()
-  const rpc = <Fn extends keyof Database['public']['Functions']>(
+  const rpc = <Fn extends Extract<keyof Database['public']['Functions'], string>>(
     fn: Fn,
     args: Database['public']['Functions'][Fn]['Args']
   ) => client.rpc(fn, args as never)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "#ui": ["./node_modules/@nuxt/ui/dist/runtime"],
       "#ui/*": ["./node_modules/@nuxt/ui/dist/runtime/*"],
-      "#tailwind-config/*": ["./tailwind-config/*"]
+      "#tailwind-config/*": ["./tailwind-config/*"],
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add baseUrl and Nuxt path aliases so vue-tsc resolves `~` and `@` imports from src
- tighten Supabase RPC helper generics to string keys across stores
- add explicit typing for vehicle option mapping and user initials computation

## Testing
- npx nuxi prepare
- npx vue-tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68daf506049c832d84a7f11f706630c5